### PR TITLE
Fix the annoying 'join us on <<date>>' button issue.

### DIFF
--- a/jade/partials/header.jade
+++ b/jade/partials/header.jade
@@ -50,7 +50,7 @@ header#header
 				p We are community of awesome Latvian software craftsmen. Each month we host an event where we invite amazing speakers from across the world.
 				.button-group
 					a#join-event.button.big.scroll-button(href="#events") join us on
-						span 12th of apr
+						span #{events[0].date}
 					.spliter or
 					a#join-devternity.button.big.opening.devternity(href="http://devternity.com" target="_blank")
 						div(data-hover="DevTernity on 1st of Dec")


### PR DESCRIPTION
The fix is to reuse _master_ events.json latest (first) event date.

Please note: the date format used at the 'join us..' button has been
changed and is the same (no adjustmenets) as in the master events.json
file.
